### PR TITLE
add uniqueId to manage ChampionBoxList

### DIFF
--- a/src/component/ChampionComponent/ChampionComponent.js
+++ b/src/component/ChampionComponent/ChampionComponent.js
@@ -2,7 +2,7 @@ import { useState } from "react";
 import React from 'react';
 import './ChampionComponent.css';
 
-const ChampionComponent = ({ data, SetChampionBoxList, SettingChampionBoxList, className }) => {
+const ChampionComponent = ({ data, SetChampionBoxList, SettingChampionBoxList, className, uniqueId }) => {
   const championData = data;
   const [showChampionInfo, setShowChampionInfo] = useState(false);
   const [infoPosition, setInfoPosition] = useState({ x: 0, y: 0 });
@@ -155,7 +155,7 @@ const ChampionComponent = ({ data, SetChampionBoxList, SettingChampionBoxList, c
 
     SettingChampionBoxList((currentList) => {
       if (isGrandParentSetChampionBox) {
-        const index = currentList.findIndex((item) => item === championData);
+        const index = currentList.findIndex((item) => item.uniqueId === uniqueId);
         if (index > -1) {
           return [
             ...currentList.slice(0, index),
@@ -164,7 +164,11 @@ const ChampionComponent = ({ data, SetChampionBoxList, SettingChampionBoxList, c
         }
         return currentList;
       } else {
-        return [...currentList, championData];
+        const uniqueId = `key-id-${Date.now()}-${Math.floor(Math.random() * 10000)}`;
+        return [...currentList, {
+          ...championData,
+          uniqueId,
+        }];
       }
     });
   };

--- a/src/component/SetChampionBox/SetChampionBox.js
+++ b/src/component/SetChampionBox/SetChampionBox.js
@@ -8,11 +8,13 @@ const SetChampionBox = ({ SetChampionBoxList, SettingChampionBoxList }) => {
       {/* SetChampionBoxList의 각 객체를 순회하면서 ChampionComponent를 렌더링 */}
       {SetChampionBoxList.map((championData, index) => (
         <ChampionComponent // 각 항목에 고유한 key를 부여
+          key={championData.uniqueId}
           data={championData} // SetChampionBoxList의 객체를 data로 전달
           SetChampionBoxList={SetChampionBoxList} // SetChampionBoxList 전달
           SettingChampionBoxList={SettingChampionBoxList}
           championListIndex={championListIndex}
           setchampionListIndex={setchampionListIndex}
+          uniqueId={championData.uniqueId}
         />
       ))}
     </div>


### PR DESCRIPTION
### Description
This PR resolves #1 . 
The root cause of bug is that there is no way to identify each ChampionComponent. So I added unique id to identify them.

Before removing "모데카이저" at the last
<img width="1298" alt="Screenshot 2025-02-28 at 00 35 14" src="https://github.com/user-attachments/assets/87d974bc-5c21-4893-b20c-18cd015f32db" />

After removed
<img width="1308" alt="Screenshot 2025-02-28 at 00 35 23" src="https://github.com/user-attachments/assets/995e29b5-7724-411a-b4e9-838b28e8b369" />


